### PR TITLE
get MONKEYLEARN_FIELD_TO_PROCESS as a list

### DIFF
--- a/scrapy_monkeylearn/middlewares.py
+++ b/scrapy_monkeylearn/middlewares.py
@@ -27,8 +27,8 @@ class MonkeylearnMiddleware(object):
 
         token = crawler.settings.get('MONKEYLEARN_TOKEN')
         module_id = crawler.settings.get('MONKEYLEARN_MODULE')
-        field_to_classify = crawler.settings.get('MONKEYLEARN_FIELD_TO_PROCESS')
-        field_classification_output = crawler.settings.getlist('MONKEYLEARN_FIELD_OUTPUT')
+        field_to_classify = crawler.settings.getlist('MONKEYLEARN_FIELD_TO_PROCESS')
+        field_classification_output = crawler.settings.get('MONKEYLEARN_FIELD_OUTPUT')
         batch_size = crawler.settings.get('MONKEYLEARN_BATCH_SIZE', 200)
         use_sandbox = crawler.settings.get('MONKEYLEARN_USE_SANDBOX', False)
 


### PR DESCRIPTION
The `MONKEYLEARN_FIELD_TO_PROCESS` setting must be read as a list, because the user can define more than one field to analyze with MonkeyLearn.

`MONKEYLEARN_FIELD_OUTPUT` is a single value, though.
