### PR TITLE
Fix 'batch_size > # of items' issue (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ is: `[{'label': 'English', 'probability': 0.321}]`.
 
 # Usage
 
-In your settings.py file, add the previously described settings and add `MonkeylearnMiddleware` to your middlewares, e.g.:
+In your settings.py file, add the previously described settings and add `MonkeylearnMiddleware` to your middlewares **with a low number (such as `1`)**, so that this middleware is the last one to be executed when the data is going from the spider to Scrapy engine, e.g.:
 
 ```python
 SPIDER_MIDDLEWARES = {
-    'scrapy_monkeylearn.middlewares.MonkeylearnMiddleware': 1000,
+    # the MonkeyLearnMiddleware requires a very low order number
+    'scrapy_monkeylearn.middlewares.MonkeylearnMiddleware': 1,
 }
 ```
 

--- a/scrapy_monkeylearn/middlewares.py
+++ b/scrapy_monkeylearn/middlewares.py
@@ -1,5 +1,6 @@
 import scrapy
 from monkeylearn import MonkeyLearn
+from scrapy import signals
 from scrapy.exceptions import NotConfigured
 
 
@@ -27,13 +28,14 @@ class MonkeylearnMiddleware(object):
 
         token = crawler.settings.get('MONKEYLEARN_TOKEN')
         module_id = crawler.settings.get('MONKEYLEARN_MODULE')
-        field_to_classify = crawler.settings.get('MONKEYLEARN_FIELD_TO_PROCESS')
-        field_classification_output = crawler.settings.getlist('MONKEYLEARN_FIELD_OUTPUT')
+        field_to_classify = crawler.settings.getlist('MONKEYLEARN_FIELD_TO_PROCESS')
+        field_classification_output = crawler.settings.get('MONKEYLEARN_FIELD_OUTPUT')
         batch_size = crawler.settings.get('MONKEYLEARN_BATCH_SIZE', 200)
         use_sandbox = crawler.settings.get('MONKEYLEARN_USE_SANDBOX', False)
 
         middleware = cls(token, module_id, field_to_classify,
                          field_classification_output, batch_size, use_sandbox)
+        crawler.signals.connect(middleware.spider_idle, signal=signals.spider_idle)
 
         return middleware
 
@@ -52,31 +54,47 @@ class MonkeylearnMiddleware(object):
                 yield elem
 
         if len(self.items) > self.batch_size:
-            if isinstance(self.field_to_classify, list) or isinstance(self.field_to_classify, tuple):
-                text_list = [
-                    ' '.join([unicode(item[elem]) for elem in self.field_to_classify])
-                    for item in self.items
-                ]
-            else:
-                text_list = [unicode(item[self.field_to_classify]) for item in self.items]
-            if self.module_id.startswith('cl_'):
-                res = self.ml.classifiers.classify(
-                    self.module_id,
-                    text_list,
-                    sandbox=self.use_sandbox
-                ).result
-            elif self.module_id.startswith('ex_'):
-                res = self.ml.extractors.extract(
-                    self.module_id,
-                    text_list
-                ).result
-            else:
-                res = self.ml.pipelines.run(
-                    self.module_id,
-                    text_list
-                ).result
             items = self.items
             self.items = []
-            for i, item in enumerate(items):
-                item[self.field_classification_output] = res[i]
+            for item in self.analyze_with_monkeylearn(items):
                 yield item
+
+    def spider_idle(self, spider):
+        items = self.items
+        self.items = []
+        for item in self.analyze_with_monkeylearn(items):
+            # Warning: this requires this middleware's process_spider_output()
+            # to be last one to execute among the middlewares, because the call
+            # below sends the items directly into the pipelines. So, use a
+            # small number for this middleware order in settings, such as 1.
+            spider.crawler.engine.scraper._process_spidermw_output(
+                item, None, scrapy.http.Response(''), spider
+            )
+
+    def analyze_with_monkeylearn(self, items):
+        if isinstance(self.field_to_classify, list) or isinstance(self.field_to_classify, tuple):
+            text_list = [
+                ' '.join([unicode(item[elem]) for elem in self.field_to_classify])
+                for item in items
+            ]
+        else:
+            text_list = [unicode(item[self.field_to_classify]) for item in items]
+        if self.module_id.startswith('cl_'):
+            res = self.ml.classifiers.classify(
+                self.module_id,
+                text_list,
+                sandbox=self.use_sandbox
+            ).result
+        elif self.module_id.startswith('ex_'):
+            res = self.ml.extractors.extract(
+                self.module_id,
+                text_list
+            ).result
+        else:
+            res = self.ml.pipelines.run(
+                self.module_id,
+                text_list
+            ).result
+        for i, item in enumerate(items):
+            item[self.field_classification_output] = res[i]
+            yield item


### PR DESCRIPTION
This fixes https://github.com/monkeylearn/scrapy-monkeylearn/issues/10

This adds a final step in the middleware where the items remaining in the buffer are sent to MonkeyLearn analysis before the spider gets closed.

However, this update is backwards incompatible because it depends on users updating their `settings.py` file to use a low number (1) for this middleware order, so that this middleware `process_spider_output` method is the last one to be executed. If it's not the last one, the middlewares after it will not be executed without further notice.

That happens because [`spider.crawler.engine.scraper._process_spidermw_output` in line 70](https://github.com/stummjr/scrapy-monkeylearn/blob/fix-batchsize-issue/scrapy_monkeylearn/middlewares.py#L70) sends the items directly to the item pipelines, stepping over further middlewares.

Is there another solution to send the the items still on buffer before the spider gets closed?